### PR TITLE
Fix GitHub Pages deploy artifact

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -25,10 +25,9 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: build-artifact
           path: ./build
 
   deploy:


### PR DESCRIPTION
## Summary

Fixes the failing `deploy` job:

```
No artifacts named "github-pages" were found for this workflow run.
```

The `build` job uploaded a generic artifact with `actions/upload-artifact` (named `build-artifact`), but `actions/deploy-pages@v4` looks for the special **`github-pages`** Pages artifact produced by `actions/upload-pages-artifact`. Swapping the upload step to `actions/upload-pages-artifact@v3` produces the correctly-named, Pages-formatted artifact that `deploy-pages` automatically downloads and publishes.

No change needed in the `deploy` job — `deploy-pages@v4` resolves the `github-pages` artifact on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZick5CNaRjPMQgZQwFu7v)_